### PR TITLE
Specify git-clone options

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-## Resumable git clone
+# Resumable git clone
 
 Clone a large repo without retrying again and again.
 
 ## how to use
 
 - clone this repo or just download the rgit.sh file into your pc
-- `./rgit.sh [git repo url]`
+- `./rgit.sh [-h|--help] [git_repo_url [dir] [...git_clone_options]]`
 - sip tee
 
 you can also put `rgit.sh` to your $PATH, so you don't need to open this repo to call this command
@@ -17,10 +17,10 @@ if you happened to stop this script ,and you wanna restart the clone,
 - `cd` to the dir of your repo
 - run `rgit.sh` (so I suggest you to add rgit.sh to your $PATH)
 
-
 ## tricky files
 
 To make this script works, I will create the following files in the cloned repo directory to record the process.
+
 - rgit.out  -> used to record the git output, so rgit can know if the fetch is done or not (You can delete it if you interrupt the process, the script will create a new one, nothing goes wrong)
 - .resumable_git_depth -> used to record the git fetched depth, so rgit can know where to start from. This file is necessary if you wanna resume the clone. (deleting this file will stop this script from resuming the clone.You can of course set up a custom depth in this file to continue the clone by yourself)
 
@@ -28,7 +28,7 @@ To make this script works, I will create the following files in the cloned repo 
 
 This is the output about how it works when I try to clone redis from github. It's really a hard fight, you can't image how much work you will have to do if you do it manually
 
-```
+```shell
 rgit https://github.com/antirez/redis.git
 now clone one layer
 fetch depth 2

--- a/rgit.sh
+++ b/rgit.sh
@@ -3,6 +3,16 @@
 DEPTH_RECORD_FILE=.resumable_git_depth
 OUT_FILE=rgit.out
 
+if [ "-h" = "$1" ] || [ "--help" = "$1" ]
+then
+    cat <<EOF
+Clone a large git_repo without retrying again and again.
+
+Usage: $0 [-h|--help] [git_repo_url [dir] [...git_clone_options]]
+EOF
+    exit 2
+fi
+
 if [ 0 -eq $# ]
 then
     depth=`cat ${DEPTH_RECORD_FILE}`
@@ -11,20 +21,40 @@ then
         echo "can not find resume record in current dir"
         exit 1
     fi
-elif [ 1 -eq $# ]
-then
+else
     echo "now clone the 1st layer"
-    clone_str=`git clone --depth 1 $1 2>&1|grep Cloning`
-    [[ "$clone_str" =~ \'(.*)\' ]] && work_dir=${BASH_REMATCH[1]}
 
-    if [[ "$work_dir" == "" ]]
+    if [ ! -z "$2" ] && [ "-" != ${2:0:1} ]
     then
-        echo "fail to clone"
-        exit 1
+        target_dir="$2"
     fi
 
-    cd $work_dir
-    depth=2
+    clone_str=`git clone --depth 1 "$@" 2>&1 | grep Cloning`
+
+    if [ -z "$target_dir" ]
+    then
+        if [[ "$clone_str" =~ \'(.*)\' ]]
+        then
+            work_dir=${BASH_REMATCH[1]}
+
+            if [[ "$work_dir" == "" ]]
+            then
+                echo "fail to clone"
+                exit 1
+            fi
+
+            cd $work_dir
+        fi
+    else
+        cd "$target_dir"
+    fi
+
+    if [ -e "$DEPTH_RECORD_FILE" ]
+    then
+        depth=`cat ${DEPTH_RECORD_FILE}`
+    else
+        depth=2
+    fi
 fi
 
 step=1


### PR DESCRIPTION
The `rgit.sh` is small but quite useful. It helps me a lot to clone an extremely large-scale open-source project recently. Thank you a lot for creating this tool.

Per my personal experience, I modify the script to allow me to specify `git clone` options, e.g. setting target directory, adding special option like `-4`, etc. And I also do some code refactory work.